### PR TITLE
Deprecate set-output and bump `actions/checkout`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.sha }}
         # we need this commit + the last so we can compare below

--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -15,8 +15,8 @@ VERSION_BEFORE="$(git show "$BEFORE":package.json | jq --raw-output .version)"
 VERSION_AFTER="$(jq --raw-output .version package.json)"
 if [[ "$VERSION_BEFORE" == "$VERSION_AFTER" ]]; then
   echo "Notice: version unchanged. Skipping release."
-  echo "::set-output name=IS_RELEASE::false"
+  echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
   exit 0
 fi
  
-echo "::set-output name=IS_RELEASE::true"
+echo "IS_RELEASE=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
remove set-output re: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/