### PR TITLE
Add 'commit-starts-with' optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,30 @@
 
 ## Description
 
-This action checks to see if the `.version` key in a repository's `package.json` has changed in order to determine if this commit is a release commit.
+Check whether the current commit is a release commit. Primarily this action looks at the `.version` key in a repository's `package.json` to see whether it has changed. Optionally, it can also validate that the commit message starts with a specific string.
 
 ![image](https://user-images.githubusercontent.com/675259/181828020-b54ef521-20f1-477c-83b4-3e9ac5b91398.png)
 
 ## Usage
+
+## Basic usage
+
+This will look at the current commit, comparing it to `github.event.before` to see whether the `version` field of the `package.json` file in the root directory of the repository has changed. If the version has been updated, `IS_RELEASE` will be set to `true`. Otherwise, it will be set to `false`.
+
+```yaml
+jobs:
+  is-release:
+    outputs:
+      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MetaMask/action-is-release@v1.0
+        id: is-release
+```
+
+### Filter by merge commit author
+
+Here is an example of how to use this action with a merge author filter. This will act the same as the previous example, except that it will be skipped if the commit author is anyone other than "GitHub". When skipped, `IS_RELEASE` will be unset.
 
 ```yaml
 jobs:
@@ -20,11 +39,38 @@ jobs:
       - uses: MetaMask/action-is-release@v1.0
         id: is-release
 ```
+
+### With specific commit message prefix
+
+Here is an example of how to use the `commit-starts-with` option.
+
+```yaml
+jobs:
+  is-release:
+    outputs:
+      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MetaMask/action-is-release@v1.0
+        id: is-release
+        with:
+          commit-starts-with: 'Release [version]'
+```
+
+This will set `IS_RELEASE` to `true` if triggered on a commit where the package version changed, and where the commit message starts with "Release [new package version]" (e.g "Release 1.0.0", if the package version was updated to "1.0.0").
+
+### Conditionally running release jobs
+
 You can then add filters in following jobs so those will skip if the `IS_RELEASE` criteria isn't met:
 
 ```yaml
-publish-release:
+jobs:
+  is-release:
+    < insert example from above >
+  publish-release:
     if: needs.is-release.outputs.IS_RELEASE == 'true'
     runs-on: ubuntu-latest
     needs: is-release
 ```
+
+

--- a/action.yml
+++ b/action.yml
@@ -21,4 +21,4 @@ runs:
         fetch-depth: 2
     - id: is-release
       shell: bash
-      run: ${{ github.action_path }}/scripts/is-release.sh ${{ github.event.before }} ${{ inputs.commit-starts-with }}
+      run: ${{ github.action_path }}/scripts/is-release.sh "${{ github.event.before }}" "${{ inputs.commit-starts-with }}"

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "This action checks to see if the .version key in a repository's pa
 
 inputs:
   commit-starts-with:
-    description: "Validate that the release commit starts with this string. Use '[version]'' to refer to the current release version."
+    description: "Validate that the release commit starts with this string. Use '[version]' to refer to the current release version."
     required: false
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,11 @@
 name: 'Is this a release?'
 description: "This action checks to see if the .version key in a repository's package.json has changed in order to determine if this commit is a release commit"
 
+inputs:
+  commit-starts-with:
+    description: "Validate that the release commit starts with this string. Use '[version]'' to refer to the current release version."
+    required: false
+
 outputs:
   IS_RELEASE:
     description: 'Is this a release? can be either "true" or "false".'
@@ -16,4 +21,4 @@ runs:
         fetch-depth: 2
     - id: is-release
       shell: bash
-      run: ${{ github.action_path }}/scripts/is-release.sh ${{ github.event.before }}
+      run: ${{ github.action_path }}/scripts/is-release.sh ${{ github.event.before }} ${{ inputs.commit-starts-with }}

--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -22,7 +22,7 @@ elif [[ -n $COMMIT_STARTS_WITH ]]; then
   EXPECTED_COMMIT_PREFIX="${COMMIT_STARTS_WITH//\[version\]/$VERSION_AFTER}"
   COMMIT_MESSAGE="$(git log --max-count=1 --format=%s)"
   if [[ ! $COMMIT_MESSAGE =~ ^$EXPECTED_COMMIT_PREFIX ]]; then
-    echo "Notice: commit message does not match expected format. Skipping release."
+    echo "Notice: commit message does not start with \"${COMMIT_STARTS_WITH}\". Skipping release."
     echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
     exit 0
   fi

--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -5,6 +5,7 @@ set -e
 set -o pipefail
 
 BEFORE="${1}"
+COMMIT_STARTS_WITH="${2}"
 
 if [[ -z $BEFORE ]]; then
   echo "Error: Before SHA not specified."
@@ -17,6 +18,14 @@ if [[ "$VERSION_BEFORE" == "$VERSION_AFTER" ]]; then
   echo "Notice: version unchanged. Skipping release."
   echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
   exit 0
+elif [[ -n $COMMIT_STARTS_WITH ]]; then
+  EXPECTED_COMMIT_PREFIX="${COMMIT_STARTS_WITH//\[version\]/$VERSION_AFTER}"
+  COMMIT_MESSAGE="$(git log --max-count=1 --format=%s)"
+  if [[ ! $COMMIT_MESSAGE =~ ^$EXPECTED_COMMIT_PREFIX ]]; then
+    echo "Notice: commit message does not match expected format. Skipping release."
+    echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
+    exit 0
+  fi
 fi
- 
+
 echo "IS_RELEASE=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
An optional parameter has been added to validate that the commit being evaluated starts with a specific string.

If this optional parameter is set, we will check the subject line of the current commit to ensure it matches what was expected. We will replace the string "[version]" in this parameter with the current release version.

The README has been updated to explain how this works.