### PR TITLE
Improve README example of filtering by merge author

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This action checks to see if the `.version` key in a repository's `package.json`
 ```yaml
 jobs:
   is-release:
-    # release merge commits come from GitHub user
-    if: github.event.head_commit.committer.name == 'GitHub'
+    # Filter by commits made by the author "github-actions"
+    if: github.event.head_commit.author.name == 'github-actions'
     outputs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
The example in the README of filtering by merge author is misleading, because the "committer" is always set to "GitHub" for any commit created via the GitHub UI.

Instead it has been updated to reference 'author.name', which is what we use in practice.