### PR TITLE
Support multiple commit prefixes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "This action checks to see if the .version key in a repository's pa
 
 inputs:
   commit-starts-with:
-    description: "Validate that the release commit starts with this string. Use '[version]' to refer to the current release version."
+    description: "Validate that the release commit starts with a string in this comma-separated list. Use '[version]' to refer to the current release version."
     required: false
 
 outputs:

--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -22,7 +22,7 @@ elif [[ -n $COMMIT_STARTS_WITH ]]; then
   COMMIT_MESSAGE="$(git log --max-count=1 --format=%s)"
   match_found=false
 
-  IFS=';' read -ra RAW_PREFIXES <<< "${COMMIT_STARTS_WITH}"
+  IFS=',' read -ra RAW_PREFIXES <<< "${COMMIT_STARTS_WITH}"
   for RAW_PREFIX in "${RAW_PREFIXES[@]}"; do
     EXPECTED_COMMIT_PREFIX="${RAW_PREFIX//\[version\]/$VERSION_AFTER}"
     if [[ $COMMIT_MESSAGE =~ ^$EXPECTED_COMMIT_PREFIX ]]; then

--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -19,12 +19,21 @@ if [[ "$VERSION_BEFORE" == "$VERSION_AFTER" ]]; then
   echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
   exit 0
 elif [[ -n $COMMIT_STARTS_WITH ]]; then
-  EXPECTED_COMMIT_PREFIX="${COMMIT_STARTS_WITH//\[version\]/$VERSION_AFTER}"
   COMMIT_MESSAGE="$(git log --max-count=1 --format=%s)"
-  if [[ ! $COMMIT_MESSAGE =~ ^$EXPECTED_COMMIT_PREFIX ]]; then
-    echo "Notice: commit message does not start with \"${COMMIT_STARTS_WITH}\". Skipping release."
-    echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
-    exit 0
+  match_found=false
+
+  IFS=';' read -ra RAW_PREFIXES <<< "${COMMIT_STARTS_WITH}"
+  for i in "${RAW_PREFIX[@]}"; do
+    EXPECTED_COMMIT_PREFIX="${COMMIT_STARTS_WITH//\[version\]/$VERSION_AFTER}"
+    if [[ $COMMIT_MESSAGE =~ ^$EXPECTED_COMMIT_PREFIX ]]; then
+      match_found=true
+      break;
+    fi
+  done
+
+  if [[ ! $match_found ]]; then
+      echo "Notice: commit message does not start with \"${COMMIT_STARTS_WITH}\". Skipping release."
+      echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
   fi
 fi
 

--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -23,8 +23,8 @@ elif [[ -n $COMMIT_STARTS_WITH ]]; then
   match_found=false
 
   IFS=';' read -ra RAW_PREFIXES <<< "${COMMIT_STARTS_WITH}"
-  for i in "${RAW_PREFIX[@]}"; do
-    EXPECTED_COMMIT_PREFIX="${COMMIT_STARTS_WITH//\[version\]/$VERSION_AFTER}"
+  for RAW_PREFIX in "${RAW_PREFIXES[@]}"; do
+    EXPECTED_COMMIT_PREFIX="${RAW_PREFIX//\[version\]/$VERSION_AFTER}"
     if [[ $COMMIT_MESSAGE =~ ^$EXPECTED_COMMIT_PREFIX ]]; then
       match_found=true
       break;

--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -34,6 +34,7 @@ elif [[ -n $COMMIT_STARTS_WITH ]]; then
   if [[ $match_found == false ]]; then
       echo "Notice: commit message does not start with \"${COMMIT_STARTS_WITH}\". Skipping release."
       echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
+      exit 0
   fi
 fi
 

--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -31,7 +31,7 @@ elif [[ -n $COMMIT_STARTS_WITH ]]; then
     fi
   done
 
-  if [[ ! $match_found ]]; then
+  if [[ $match_found == false ]]; then
       echo "Notice: commit message does not start with \"${COMMIT_STARTS_WITH}\". Skipping release."
       echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
   fi


### PR DESCRIPTION
We now allow the `commit-starts-with` input to be a comma-separated list of prefixes. Matching either of them is sufficient to show that a given commit is a release commit.