### PR TITLE
Add 'commit-body-starts-with' and 'package-dir' optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Check whether the current commit is a release commit. Primarily this action look
 
 ## Usage
 
-## Basic usage
+### Basic usage
 
 This will look at the current commit, comparing it to `github.event.before` to see whether the `version` field of the `package.json` file in the root directory of the repository has changed. If the version has been updated, `IS_RELEASE` will be set to `true`. Otherwise, it will be set to `false`.
 
@@ -59,6 +59,35 @@ jobs:
 
 This will set `IS_RELEASE` to `true` if triggered on a commit where the package version changed, and where the commit message starts with "Release [new package version]" (e.g "Release 1.0.0", if the package version was updated to "1.0.0").
 
+### With specific commit message body prefix
+
+Here is an example of how to use the `commit-body-starts-with` option.
+
+```yaml
+jobs:
+  is-release:
+    outputs:
+      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MetaMask/action-is-release@v1.0
+        id: is-release
+        with:
+          commit-body-starts-with: 'Release [version]'
+```
+
+This behaves the same as the `commit-starts-with` option but ignores the title of the commit message.
+
+For example, the below commit message would result in `IS_RELEASE` set to `true`, assuming the package version had still been changed.
+
+```
+Merge pull request #123 from release/1.0.0
+
+Release 1.0.0
+```
+
+This can be used to identify release commits that are also merge commits and therefore have a fixed title format.
+
 ### Conditionally running release jobs
 
 You can then add filters in following jobs so those will skip if the `IS_RELEASE` criteria isn't met:
@@ -73,4 +102,21 @@ jobs:
     needs: is-release
 ```
 
+### Alternate package directories
 
+If the relevant version is not defined in the `package.json` in the root directory, an alternate directory can be specified using the `package-dir` option.
+
+```yaml
+jobs:
+  is-release:
+    outputs:
+      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MetaMask/action-is-release@v1.0
+        id: is-release
+        with:
+          package-dir: 'packages/some-workspace'
+```
+
+This can be used to identify release commits in monorepos that contain multiple packages and therefore multiple `package.json` files with alternate versions.

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,13 @@ inputs:
   commit-starts-with:
     description: "Validate that the release commit starts with this string. Use '[version]' to refer to the current release version."
     required: false
+  commit-body-starts-with:
+    description: "Validate that the release commit body starts with this string. Use '[version]' to refer to the current release version."
+    required: false
+  package-dir:
+    description: "Directory containing the package.json file with the relevant version. For example, a monorepo workspace directory."
+    required: false
+    default: "."
 
 outputs:
   IS_RELEASE:
@@ -21,4 +28,4 @@ runs:
         fetch-depth: 2
     - id: is-release
       shell: bash
-      run: ${{ github.action_path }}/scripts/is-release.sh "${{ github.event.before }}" "${{ inputs.commit-starts-with }}"
+      run: ${{ github.action_path }}/scripts/is-release.sh "${{ github.event.before }}" "${{ inputs.commit-starts-with }}" "${{ inputs.commit-body-starts-with }}" "${{ inputs.package-dir }}"

--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -6,14 +6,22 @@ set -o pipefail
 
 BEFORE="${1}"
 COMMIT_STARTS_WITH="${2}"
+COMMIT_BODY_STARTS_WITH="${3}"
+PACKAGE_DIR="${4}"
 
 if [[ -z $BEFORE ]]; then
   echo "Error: Before SHA not specified."
   exit 1
 fi
 
-VERSION_BEFORE="$(git show "$BEFORE":package.json | jq --raw-output .version)"
-VERSION_AFTER="$(jq --raw-output .version package.json)"
+if [[ -z $PACKAGE_DIR ]]; then
+  echo "Error: Package directory not specified."
+  exit 1
+fi
+
+VERSION_BEFORE="$(git show "$BEFORE":"$PACKAGE_DIR"/package.json | jq --raw-output .version)"
+VERSION_AFTER="$(jq --raw-output .version "$PACKAGE_DIR"/package.json)"
+
 if [[ "$VERSION_BEFORE" == "$VERSION_AFTER" ]]; then
   echo "Notice: version unchanged. Skipping release."
   echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
@@ -21,8 +29,18 @@ if [[ "$VERSION_BEFORE" == "$VERSION_AFTER" ]]; then
 elif [[ -n $COMMIT_STARTS_WITH ]]; then
   EXPECTED_COMMIT_PREFIX="${COMMIT_STARTS_WITH//\[version\]/$VERSION_AFTER}"
   COMMIT_MESSAGE="$(git log --max-count=1 --format=%s)"
+
   if [[ ! $COMMIT_MESSAGE =~ ^$EXPECTED_COMMIT_PREFIX ]]; then
     echo "Notice: commit message does not start with \"${COMMIT_STARTS_WITH}\". Skipping release."
+    echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
+    exit 0
+  fi
+elif [[ -n $COMMIT_BODY_STARTS_WITH ]]; then
+  EXPECTED_COMMIT_BODY_PREFIX="${COMMIT_BODY_STARTS_WITH//\[version\]/$VERSION_AFTER}"
+  COMMIT_MESSAGE="$(git log --max-count=1 --format=%b)"
+
+  if [[ ! $COMMIT_MESSAGE =~ ^$EXPECTED_COMMIT_BODY_PREFIX ]]; then
+    echo "Notice: commit message body does not start with \"${EXPECTED_COMMIT_BODY_PREFIX}\". Skipping release."
     echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
     exit 0
   fi


### PR DESCRIPTION
Adds the following optional parameters:

`commit-body-starts-with`: Used to identify release commits that are also merge commits.
This is required by [MetaMask Desktop](https://github.com/MetaMask/metamask-desktop) which currently does merge commits to a stable branch to retain Git history.

`package-dir`: Used to specify an alternate directory containing the `package.json` with the relevant version.
This is useful for monorepos with split release processes per workspace, as in MetaMask Desktop.

The README has been updated accordingly, see [here](https://github.com/MetaMask/action-is-release/blob/1ce9f82a50063fb7f054a4a9206d7f96d5a76676/README.md#with-specific-commit-message-body-prefix) for markdown.