### PR TITLE
BREAKING: Bump `actions/checkout` to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.sha }}
         # we need this commit + the last so we can compare below


### PR DESCRIPTION
Closes #10.

`actions/checkout@v3` uses Node 16 which is deprecated. This bumps it to v4 to use Node 20 instead.