### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0]
+
+### Changed
+
+- **BREAKING:** Bump `actions/checkout` to `v4` ([#11](https://github.com/MetaMask/action-is-release/pull/11))
+  - This is a breaking change because `actions/checkout@v4` uses Node 20.
+- Support multiple commit prefixes ([#6](https://github.com/MetaMask/action-is-release/pull/6))
+
+[Unreleased]: https://github.com/MetaMask/action-is-release/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/action-is-release/releases/tag/v2.0.0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     runs-on: ubuntu-latest
     steps:
-      - uses: MetaMask/action-is-release@v1.0
+      - uses: MetaMask/action-is-release@v2
         id: is-release
 ```
 
@@ -36,7 +36,7 @@ jobs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     runs-on: ubuntu-latest
     steps:
-      - uses: MetaMask/action-is-release@v1.0
+      - uses: MetaMask/action-is-release@v2
         id: is-release
 ```
 
@@ -51,7 +51,7 @@ jobs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     runs-on: ubuntu-latest
     steps:
-      - uses: MetaMask/action-is-release@v1.0
+      - uses: MetaMask/action-is-release@v2
         id: is-release
         with:
           commit-starts-with: 'Release [version]'


### PR DESCRIPTION
This is the release candidate for version 2.0.0.

This repository previously did not have a changelog, so I've added one, starting from this version.