### PR TITLE
feat: Add options to check if a pull request is a release PR

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: "Validate that the release commit starts with a string in this comma-separated list. Use '[version]' to refer to the current release version."
     required: false
 
+  before:
+    description: "The commit SHA before the current commit."
+    required: false
+    default: ${{ github.event.before }}
+
 outputs:
   IS_RELEASE:
     description: 'Is this a release? can be either "true" or "false".'
@@ -21,4 +26,4 @@ runs:
         fetch-depth: 2
     - id: is-release
       shell: bash
-      run: ${{ github.action_path }}/scripts/is-release.sh "${{ github.event.before }}" "${{ inputs.commit-starts-with }}"
+      run: ${{ github.action_path }}/scripts/is-release.sh "${{ inputs.before }}" "${{ inputs.commit-starts-with }}"

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: "Validate that the release commit starts with a string in this comma-separated list. Use '[version]' to refer to the current release version."
     required: false
 
+  commit-message:
+    description: "The commit message to check. If not provided, the action will get the message from the current commit."
+    required: false
+    default: ""
+
   before:
     description: "The commit SHA before the current commit."
     required: false
@@ -26,4 +31,4 @@ runs:
         fetch-depth: 2
     - id: is-release
       shell: bash
-      run: ${{ github.action_path }}/scripts/is-release.sh "${{ inputs.before }}" "${{ inputs.commit-starts-with }}"
+      run: ${{ github.action_path }}/scripts/is-release.sh "${{ inputs.before }}" "${{ inputs.commit-starts-with }}" "${{ inputs.commit-message }}"

--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -6,6 +6,7 @@ set -o pipefail
 
 BEFORE="${1}"
 COMMIT_STARTS_WITH="${2}"
+COMMIT_MESSAGE="${3}"
 
 if [[ -z $BEFORE ]]; then
   echo "Error: Before SHA not specified."
@@ -19,7 +20,10 @@ if [[ "$VERSION_BEFORE" == "$VERSION_AFTER" ]]; then
   echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
   exit 0
 elif [[ -n $COMMIT_STARTS_WITH ]]; then
-  COMMIT_MESSAGE="$(git log --max-count=1 --format=%s)"
+  if [[ -z $COMMIT_MESSAGE ]]; then
+    COMMIT_MESSAGE="$(git log --max-count=1 --format=%s)"
+  fi
+
   match_found=false
 
   IFS=',' read -ra RAW_PREFIXES <<< "${COMMIT_STARTS_WITH}"

--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -13,8 +13,11 @@ if [[ -z $BEFORE ]]; then
   exit 1
 fi
 
+git fetch origin "$BEFORE"
+
 VERSION_BEFORE="$(git show "$BEFORE":package.json | jq --raw-output .version)"
 VERSION_AFTER="$(jq --raw-output .version package.json)"
+
 if [[ "$VERSION_BEFORE" == "$VERSION_AFTER" ]]; then
   echo "Notice: version unchanged. Skipping release."
   echo "IS_RELEASE=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This adds a couple (optional) options to the action which we can use to check if an unmerged pull request is a release pull request:

- `before` allows us to override the before commit hash.
- `commit-message` allows us to set the commit message to check, e.g., the title of the unmerged pull request.

Example usage here: https://github.com/MetaMask/core/blob/56f08cb1852461022d2964a7c61f720f87ceb5fc/.github/workflows/main.yml#L71-L77

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `before` and `commit-message` inputs and updates the script to use them for version comparison and commit-prefix validation.
> 
> - **GitHub Action (`action.yml`)**:
>   - Add optional inputs `before` (override previous SHA) and `commit-message` (explicit message to validate).
>   - Update step to pass `inputs.before` and `inputs.commit-message` to `scripts/is-release.sh`.
> - **Script (`scripts/is-release.sh`)**:
>   - Accept third arg `COMMIT_MESSAGE` and `git fetch origin "$BEFORE"` before reading `package.json` at `BEFORE`.
>   - If versions unchanged, output `IS_RELEASE=false` and exit.
>   - Use provided `COMMIT_MESSAGE` (fallback to latest commit subject) and validate it starts with any of `commit-starts-with` (supports `[version]` substitution); if no match, output `IS_RELEASE=false` and exit.
>   - Otherwise set `IS_RELEASE=true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d063725cd15ee145d7e795a2e77db31a3e3f2c92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->