### PR TITLE
fix: Use environment variables for script inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,4 +31,8 @@ runs:
         fetch-depth: 2
     - id: is-release
       shell: bash
-      run: ${{ github.action_path }}/scripts/is-release.sh "${{ inputs.before }}" "${{ inputs.commit-starts-with }}" "${{ inputs.commit-message }}"
+      env:
+        BEFORE: ${{ inputs.before }}
+        COMMIT_STARTS_WITH: ${{ inputs.commit-starts-with }}
+        COMMIT_MESSAGE: ${{ inputs.commit-message }}
+      run: ${{ github.action_path }}/scripts/is-release.sh

--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -4,10 +4,6 @@ set -x
 set -e
 set -o pipefail
 
-BEFORE="${1}"
-COMMIT_STARTS_WITH="${2}"
-COMMIT_MESSAGE="${3}"
-
 if [[ -z $BEFORE ]]; then
   echo "Error: Before SHA not specified."
   exit 1
@@ -20,7 +16,7 @@ VERSION_AFTER="$(jq --raw-output .version package.json)"
 
 if [[ "$VERSION_BEFORE" == "$VERSION_AFTER" ]]; then
   echo "Notice: version unchanged. Skipping release."
-  echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
+  echo "IS_RELEASE=false" >> "$GITHUB_OUTPUT"
   exit 0
 elif [[ -n $COMMIT_STARTS_WITH ]]; then
   if [[ -z $COMMIT_MESSAGE ]]; then
@@ -40,9 +36,9 @@ elif [[ -n $COMMIT_STARTS_WITH ]]; then
 
   if [[ $match_found == false ]]; then
       echo "Notice: commit message does not start with \"${COMMIT_STARTS_WITH}\". Skipping release."
-      echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
+      echo "IS_RELEASE=false" >> "$GITHUB_OUTPUT"
       exit 0
   fi
 fi
 
-echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
+echo "IS_RELEASE=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Instead of passing arguments to the script, we can use environment variables.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the is-release action to supply inputs via environment variables and updates the script to consume them, adding safe quoting for GITHUB_OUTPUT writes.
> 
> - **GitHub Action (`action.yml`)**:
>   - Passes `before`, `commit-starts-with`, and `commit-message` to the step via environment variables.
>   - Runs `scripts/is-release.sh` without positional arguments.
> - **Script (`scripts/is-release.sh`)**:
>   - Removes positional-argument parsing; reads `BEFORE`, `COMMIT_STARTS_WITH`, and `COMMIT_MESSAGE` from env vars.
>   - Quotes `$GITHUB_OUTPUT` when writing `IS_RELEASE` results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebd01f8c0d1a47626e90146a7bcd99f96106949d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->