### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,24 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.1.0]
+
+### Added
+
+- Add options to check if a pull request is a release PR ([#14](https://github.com/MetaMask/action-is-release/pull/14))
+  - This adds two new optional inputs:
+    - `before`: Used to check commits before a specific SHA (e.g., the base of a PR) for a version bump.
+    - `commit-message`: Used to specify the commit message to check for the release format, e.g., the pull request title.
+
+### Fixed
+
+- Use environment variables for script inputs ([#15](https://github.com/MetaMask/action-is-release/pull/15))
 
 ## [2.0.0]
 
@@ -14,5 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This is a breaking change because `actions/checkout@v4` uses Node 20.
 - Support multiple commit prefixes ([#6](https://github.com/MetaMask/action-is-release/pull/6))
 
-[Unreleased]: https://github.com/MetaMask/action-is-release/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/action-is-release/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/MetaMask/action-is-release/releases/tag/v2.1.0
 [2.0.0]: https://github.com/MetaMask/action-is-release/releases/tag/v2.0.0


### PR DESCRIPTION
This is the release candidate for version 2.1.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update CHANGELOG for 2.1.0 with new inputs (`before`, `commit-message`), env var fix, and link updates.
> 
> - **Docs**: `CHANGELOG.md`
>   - Add `2.1.0` section:
>     - *Added*: options to check release PRs (`before`, `commit-message`).
>     - *Fixed*: use environment variables for script inputs.
>   - Update `[Unreleased]` compare link and add `[2.1.0]` release link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2f6bfd2dcd8f3758eb715f5a72bc591b970f4a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->