### PR TITLE
feat: Add option to skip checkout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,11 @@ inputs:
     required: false
     default: ${{ github.event.before }}
 
+  skip-checkout:
+    description: "If 'true', the action will skip the checkout step. Use this if the repository has already been checked out. Note that the action requires at least two commits to be fetched."
+    required: false
+    default: "false"
+
 outputs:
   IS_RELEASE:
     description: 'Is this a release? can be either "true" or "false".'
@@ -25,6 +30,7 @@ runs:
   using: 'composite'
   steps:
     - uses: actions/checkout@v4
+      if: ${{ inputs.skip-checkout != 'true' }}
       with:
         ref: ${{ github.sha }}
         # we need this commit + the last so we can compare below


### PR DESCRIPTION
This adds an option to skip checkout, which is useful in cases where the repository is already checked out earlier in the job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add optional `skip-checkout` input and conditionally run `actions/checkout@v4` based on it.
> 
> - **Action inputs**:
>   - Add `skip-checkout` (default: "false") to allow skipping repository checkout when already performed.
> - **Run steps**:
>   - Make `actions/checkout@v4` conditional on `inputs.skip-checkout != 'true'` in `action.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50dbf463e1bd8c2d6774b3d018ac47f8702da9a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->