### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0]
+
+### Added
+
+- Add option to skip checkout ([#17](https://github.com/MetaMask/action-is-release/pull/17))
+  - This is useful when the action is used in a workflow that has already checked out the repository.
+
 ## [2.1.0]
 
 ### Added
@@ -28,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This is a breaking change because `actions/checkout@v4` uses Node 20.
 - Support multiple commit prefixes ([#6](https://github.com/MetaMask/action-is-release/pull/6))
 
-[Unreleased]: https://github.com/MetaMask/action-is-release/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/action-is-release/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/MetaMask/action-is-release/releases/tag/v2.2.0
 [2.1.0]: https://github.com/MetaMask/action-is-release/releases/tag/v2.1.0
 [2.0.0]: https://github.com/MetaMask/action-is-release/releases/tag/v2.0.0


### PR DESCRIPTION
This is the release candidate for version `2.2.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CHANGELOG for 2.2.0, documenting the new "skip checkout" option and adjusting release links.
> 
> - **Changelog**:
>   - Add `2.2.0` section under **Added**:
>     - Document new option to skip checkout (`#17`).
>   - Update reference links:
>     - `[Unreleased]` now compares `v2.2.0...HEAD`.
>     - Add link for `[2.2.0]` release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c616a2918dd1c9b63af39812fb604b04ff163eac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->