### PR TITLE
feat: only enable `set -x` when `RUNNER_DEBUG` is set

### DIFF
--- a/scripts/is-release.sh
+++ b/scripts/is-release.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-set -x
 set -e
 set -o pipefail
+
+if [ "${RUNNER_DEBUG:-}" = "1" ]; then
+  set -x
+fi
 
 if [[ -z $BEFORE ]]; then
   echo "Error: Before SHA not specified."


### PR DESCRIPTION
The script was unconditionally running with `set -x`, producing verbose trace output on every workflow run. This change gates the debug tracing behind the standard `RUNNER_DEBUG=1` flag, so it only activates when a runner has debug logging enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral change in a release helper script with no effect on release decisions or production code.
> 
> **Overview**
> **`scripts/is-release.sh`** no longer enables bash trace mode on every run. The unconditional **`set -x`** at startup was removed and replaced with a check on **`RUNNER_DEBUG`**: tracing runs only when that variable is **`1`**, matching the usual GitHub Actions debug flag.
> 
> Release/version logic is unchanged; only default workflow log verbosity is reduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eeff626c1e536c1cad83b75d73d1bd476e48a22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->